### PR TITLE
Enable rollup.enabletxpooladmission When Launching op-geth for Public RPC Node

### DIFF
--- a/L2/gamma_testnet_new_node.md
+++ b/L2/gamma_testnet_new_node.md
@@ -55,9 +55,9 @@ mkdir safedb
   --authrpc.vhosts="*" \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=./jwt.txt \
-  --rollup.disabletxpoolgossip=true \
+  --rollup.disabletxpoolgossip \
   --rollup.sequencerhttp=http://65.109.115.36:8545 \
-  --rollup.enabletxpooladmission=true 2>&1 | tee -a geth.log -i
+  --rollup.enabletxpooladmission 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=consensus-layer)
 Locate the sequencer's peer ID and replace it in the p2p.static option:
@@ -102,9 +102,9 @@ Locate the sequencer's peer ID and replace it in the p2p.static option:
   --authrpc.vhosts="*" \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=./jwt.txt \
-  --rollup.disabletxpoolgossip=true \
+  --rollup.disabletxpoolgossip \
   --rollup.sequencerhttp=http://65.109.69.90:8545 \
-  --rollup.enabletxpooladmission=true \
+  --rollup.enabletxpooladmission \
   --bootnodes enode://7c9422be3825257ac80f89968e7e6dd3f64608199640ae6cea07b59d2de57642568908974ed4327f092728a64c7bdc04130ebbeaa607b6a1b95d0d25e9c5330b@65.109.69.90:30303 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=execution-layer)
@@ -152,9 +152,9 @@ Replace the public node's peer ID in the p2p.static option:
   --authrpc.vhosts="*" \
   --authrpc.port=8551 \
   --authrpc.jwtsecret=./jwt.txt \
-  --rollup.disabletxpoolgossip=true \
+  --rollup.disabletxpoolgossip \
   --rollup.sequencerhttp=http://65.109.69.90:8545 \
-  --rollup.enabletxpooladmission=true \
+  --rollup.enabletxpooladmission \
   --bootnodes enode://7c9422be3825257ac80f89968e7e6dd3f64608199640ae6cea07b59d2de57642568908974ed4327f092728a64c7bdc04130ebbeaa607b6a1b95d0d25e9c5330b@65.109.69.90:30303 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=execution-layer)

--- a/L2/gamma_testnet_new_node.md
+++ b/L2/gamma_testnet_new_node.md
@@ -56,7 +56,8 @@ mkdir safedb
   --authrpc.port=8551 \
   --authrpc.jwtsecret=./jwt.txt \
   --rollup.disabletxpoolgossip=true \
-  --rollup.sequencerhttp=http://65.109.115.36:8545 2>&1 | tee -a geth.log -i
+  --rollup.sequencerhttp=http://65.109.115.36:8545 \
+  --rollup.enabletxpooladmission=true 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=consensus-layer)
 Locate the sequencer's peer ID and replace it in the p2p.static option:
@@ -103,6 +104,7 @@ Locate the sequencer's peer ID and replace it in the p2p.static option:
   --authrpc.jwtsecret=./jwt.txt \
   --rollup.disabletxpoolgossip=true \
   --rollup.sequencerhttp=http://65.109.69.90:8545 \
+  --rollup.enabletxpooladmission=true \
   --bootnodes enode://7c9422be3825257ac80f89968e7e6dd3f64608199640ae6cea07b59d2de57642568908974ed4327f092728a64c7bdc04130ebbeaa607b6a1b95d0d25e9c5330b@65.109.69.90:30303 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=execution-layer)
@@ -152,6 +154,7 @@ Replace the public node's peer ID in the p2p.static option:
   --authrpc.jwtsecret=./jwt.txt \
   --rollup.disabletxpoolgossip=true \
   --rollup.sequencerhttp=http://65.109.69.90:8545 \
+  --rollup.enabletxpooladmission=true \
   --bootnodes enode://7c9422be3825257ac80f89968e7e6dd3f64608199640ae6cea07b59d2de57642568908974ed4327f092728a64c7bdc04130ebbeaa607b6a1b95d0d25e9c5330b@65.109.69.90:30303 2>&1 | tee -a geth.log -i
 ```
 ### 2. Launch op-node (syncmode=execution-layer)


### PR DESCRIPTION
Setting the `rollup.enabletxpooladmission` flag allows op-geth to add RPC-submitted transactions to the txpool. This ensures that applications querying `eth_getTransactionCount` with "pending" can retrieve the correct pending nonce.
