### PR TITLE
minor fix

### DIFF
--- a/L2/delta_testnet_new_node.md
+++ b/L2/delta_testnet_new_node.md
@@ -8,11 +8,12 @@ This document provides instructions for building binaries and setting up various
 Clone the repository and build op-geth:
 ```bash
 git clone -b delta_testnet https://github.com/QuarkChain/op-geth.git
-cd op-geth && make geth
+pushd op-geth && make geth
 
 curl -LO https://raw.githubusercontent.com/QuarkChain/pm/refs/heads/main/L2/assets/delta_testnet_genesis.json
 ./build/bin/geth init --datadir=datadir --state.scheme hash delta_testnet_genesis.json
 openssl rand -hex 32 > jwt.txt
+popd
 ```
 
 ### 2. Building op-node

--- a/L2/gamma_testnet_new_node.md
+++ b/L2/gamma_testnet_new_node.md
@@ -8,11 +8,12 @@ This document provides instructions for building binaries and setting up various
 Clone the repository and build op-geth:
 ```bash
 git clone -b gamma_testnet https://github.com/QuarkChain/op-geth.git
-cd op-geth && make geth
+pushd op-geth && make geth
 
 curl -LO https://raw.githubusercontent.com/QuarkChain/pm/main/L2/assets/gamma_testnet_genesis.json
 ./build/bin/geth init --datadir=datadir --state.scheme hash gamma_testnet_genesis.json
 openssl rand -hex 32 > jwt.txt
+popd
 ```
 
 ### 2. Building op-node

--- a/L2/mainnet_new_node.md
+++ b/L2/mainnet_new_node.md
@@ -8,11 +8,12 @@ This document provides instructions for building binaries and setting up various
 Clone the repository and build op-geth:
 ```bash
 git clone -b qkc_mainnet_v1 https://github.com/QuarkChain/op-geth.git
-cd op-geth && make geth
+pushd op-geth && make geth
 
 curl -LO https://raw.githubusercontent.com/QuarkChain/pm/refs/heads/main/L2/assets/mainnet_genesis.json
 ./build/bin/geth init --datadir=datadir --state.scheme hash mainnet_genesis.json
 openssl rand -hex 32 > jwt.txt
+popd
 ```
 
 ### 2. Building op-node


### PR DESCRIPTION
Use pushd/popd so that after building op-geth, the user is ready to run the steps for op-node without needing to manually return to the parent directory.